### PR TITLE
Add 42 user image dans la liste des avatars par defauts

### DIFF
--- a/frontend/src/components/User/Settings/Settings.tsx
+++ b/frontend/src/components/User/Settings/Settings.tsx
@@ -155,8 +155,7 @@ const Settings = () => {
     //  toast.success('Avatar par défaut enregistré avec succès');
     //}
   };
-  
-
+  var image42:string = localStorage.getItem('42image') as string;
   return (
 
      
@@ -246,7 +245,9 @@ const Settings = () => {
       <Modal isOpen={isDefaultModalOpen}>
         <h2>Choisir un avatar par défaut</h2>
         <div>   
-          {/* ajouter la photo 42 */}
+          {image42 !== 'null' && ( 
+            <img className="imglist" src={image42} alt="Avatar" onClick={() => setSelectedDefaultAvatar(() => image42)} />
+          )}
           <img className="imglist" src={test}  alt="Avatar4" onClick={() => setSelectedDefaultAvatar(() => test)} />
           <img className="imglist" src={arcencielfille}  alt="Avatar1" onClick={() => setSelectedDefaultAvatar(() => arcencielfille)} />
           <img className="imglist" src={chat}  alt="Avatar2" onClick={() => setSelectedDefaultAvatar(() => chat)} />

--- a/frontend/src/components/page1.tsx
+++ b/frontend/src/components/page1.tsx
@@ -130,9 +130,9 @@ export default function Page1() {
           userContext.setUser(JSON.parse(userJSON));
           setDirection("/profile");
         }
-
-
-
+        if ( localStorage.getItem("42image") === null) {
+          localStorage.setItem("42image", user_info.image.link);
+        }
         setRedirect(true);
       }
     };


### PR DESCRIPTION
Add 42 user image dans la liste des avatars par defauts

ref : [trello](https://trello.com/c/WQLPmg81/21-garder-en-memoire-la-photo-de-42-pour-la-proposer-dans-les-avatar-par-defaut)

utilisation de localstorage (key = 42image,value = link )

utilisation du retour de "get_user_info()" dans page1.tsx pour eviter les call api inutile en plus